### PR TITLE
Change inclusion of Doctrine Extension to bridge

### DIFF
--- a/src/Symfony/Bundle/DoctrinePHPCRBundle/DependencyInjection/DoctrinePHPCRExtension.php
+++ b/src/Symfony/Bundle/DoctrinePHPCRBundle/DependencyInjection/DoctrinePHPCRExtension.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Bundle\DoctrineAbstractBundle\DependencyInjection\AbstractDoctrineExtension;
+use Symfony\Bridge\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Definition\Processor;
 


### PR DESCRIPTION
see https://github.com/symfony/symfony/pull/2484

as this will break compatibility of DoctrinePHPCRBundle with symfony 2.0 we should create a tag before merging this.
