### PR TITLE
Handle case where main menu does not have a current item.

### DIFF
--- a/src/Symfony/Cmf/Bundle/CoreBundle/Resources/views/Default/navigation.html.twig
+++ b/src/Symfony/Cmf/Bundle/CoreBundle/Resources/views/Default/navigation.html.twig
@@ -1,13 +1,13 @@
+{% set currentItem = knp_menu_get('main').currentItem %}
+{% if currentItem %}
 <div class="cmf-breadcrumb">
     <ul>
-        {% set currentItem = knp_menu_get('main').currentItem %}
-        {% if currentItem %}
         {% for title, url in currentItem.breadcrumbsArray %}
             <li><a href="{{url}}">{{ title }}</a></li>
         {% endfor %}
-        {% endif %}
     </ul>
 </div>
+{% endif %}
 
 <h2 class="offset">Main navigation</h2>
 


### PR DESCRIPTION
This gave me a problem on my first clean install of cmf-sandbox. Everything else worked (more or less) after this change.
