### PR TITLE
adding contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+Contributing
+------------
+
+Symfony2 CMF is an open source, community-driven project. We follow the same
+guidelines as core Symfony2. If you'd like to contribute, please read the
+[Contributing Code][1] part of the documentation. If you're submitting a pull
+request, please follow the guidelines in the [Submitting a Patch][2] section
+and use the [Pull Request Template][3].
+
+[1]: http://symfony.com/doc/current/contributing/code/index.html
+[2]: http://symfony.com/doc/current/contributing/code/patches.html#check-list
+[3]: http://symfony.com/doc/current/contributing/code/patches.html#make-a-pull-request


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | - |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/commit/d63e63dcd6f0364d76e1b189bc0db91552498b13 (that should be a PR and not a commit normally, of course) |

as discussed in the weekly irc meeting, we want to follow the symfony contribution guidelines. adding this file will make github show a link to the guidelines when you create a PR.

lets agree on the exact wording and all here, then we need to add that file to every repo that should follow the guidelines. that would be 
- every repo in the symfony-cmf organisation
- doctrine phpcr bundle
- sonata phpcr admin
- any others? i guess for jackalope / phpcr it makes less sense
