### PR TITLE
Use a less restrictive doctrine version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": "~2.3",
-        "doctrine/phpcr-bundle": "1.2.*",
-        "doctrine/phpcr-odm": "1.2.*",
+        "doctrine/phpcr-bundle": "~1.2",
+        "doctrine/phpcr-odm": "~1.2",
         "symfony-cmf/core-bundle": "1.2.*",
         "symfony-cmf/content-bundle": "1.2.*",
         "symfony-cmf/menu-bundle": "1.2.*",


### PR DESCRIPTION
This allows people to use CMF 1.2 with PHPCR ODM 1.3, allowing to run a CMF 1.2 app on PHP 7.

As far as I can see, all versions included in 1.2 work on PHPCR ODM 1.3 fine.

/cc @dbu @lsmith77 